### PR TITLE
Update to asn search handler

### DIFF
--- a/src/app/code/community/FACTFinder/Asn/Model/Handler/Search.php
+++ b/src/app/code/community/FACTFinder/Asn/Model/Handler/Search.php
@@ -206,7 +206,12 @@ class FACTFinder_Asn_Model_Handler_Search extends FACTFinder_Core_Model_Handler_
     {
         $label = $option->getLabel();
         if ($filterGroup->getUnit()) {
-            $label .= ' ' . $filterGroup->getUnit();
+            //Nublue - Alex Rowe - 12/10/2016 - Added the below as the pound symbol always comes before the number
+            if(strpos($option->getFieldName(), "price") !== false){
+                $label =  preg_replace('/(£?)(\d+([\.,\d]){0,16}\d{2,4})/', $filterGroup->getUnit(). "$0", $label);
+            }else{
+                $label .= ' ' . $filterGroup->getUnit();
+            }
         }
 
         $option = array(


### PR DESCRIPTION
- Solves issue: Price filter
- Description: Price filter on catalogue list pages now correctly appends currency symbol
- Tested with Magento editions/versions: 1.9.2.4
- Tested with PHP versions: 5.6
Update to search handler to make it correctly format prices. Currently sterling only